### PR TITLE
Fix field types: convert tags to relationship type and add textarea field type

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,14 +4,13 @@ import type { Field, CollectionConfig } from 'payload/types';
 // Simplified field type strings that users will use
 export type SimpleFieldType =
   | 'text'
+  | 'textarea'
   | 'richtext'
   | 'number'
   | 'date'
   | 'email'
   | 'checkbox'
   | 'json'
-  | 'tags'
-  | 'tags[]'
   | string; // For relationships, select options with pipe separators ('Option1 | Option2 | Option3'), or '<-posts'
 
 // Simple schema definition interface

--- a/src/utils/__tests__/fieldTransformer.test.ts
+++ b/src/utils/__tests__/fieldTransformer.test.ts
@@ -36,13 +36,13 @@ describe('transformField', () => {
       relationTo: 'categories',
     });
 
-    // Special case for tags
+    // Tags should be treated as a relationship
     const tagsResult = transformField('postTags', 'tags[]');
     expect(tagsResult).toEqual({
-      type: 'select',
+      type: 'relationship',
       name: 'postTags',
       hasMany: true,
-      options: [],
+      relationTo: 'tags',
     });
   });
 
@@ -92,11 +92,13 @@ describe('transformField', () => {
 
     const tagsField = transformField('tags', 'tags');
     expect(tagsField).toEqual({
-      type: 'select',
+      type: 'relationship',
       name: 'tags',
-      hasMany: true,
-      options: [],
+      relationTo: 'tags',
     });
+    
+    const textareaField = transformField('description', 'textarea');
+    expect(textareaField).toEqual({ type: 'textarea', name: 'description' });
   });
 
   it('should default to a relationship field for unknown types', () => {

--- a/src/utils/fieldTransformer.ts
+++ b/src/utils/fieldTransformer.ts
@@ -33,15 +33,6 @@ export const transformField = (name: string, fieldType: SimpleFieldType): FieldD
   // Check if it's a many-relationship
   if (fieldType.endsWith('[]')) {
     const relationTo = fieldType.substring(0, fieldType.length - 2);
-    if (relationTo === 'tags') {
-      // Special case for tags
-      return {
-        type: 'select',
-        name,
-        hasMany: true,
-        options: [], // Will be filled during post-processing
-      };
-    }
     
     return {
       type: 'relationship',
@@ -71,6 +62,8 @@ export const transformField = (name: string, fieldType: SimpleFieldType): FieldD
   switch (fieldType) {
     case 'text':
       return { type: 'text', name };
+    case 'textarea':
+      return { type: 'textarea', name };
     case 'richtext':
       return { type: 'richText', name };
     case 'number':
@@ -83,13 +76,6 @@ export const transformField = (name: string, fieldType: SimpleFieldType): FieldD
       return { type: 'checkbox', name };
     case 'json':
       return { type: 'json', name };
-    case 'tags':
-      return { 
-        type: 'select', 
-        name,
-        hasMany: true,
-        options: [] // Will be filled during post-processing
-      };
     default:
       // Assume it's a simple relationship
       return {


### PR DESCRIPTION
This PR addresses issue #8 by:

1. Converting 'tags' and 'tags[]' to be relationship types instead of select types
2. Adding the missing 'textarea' field type
3. Updating tests to reflect these changes

All tests are passing with these changes.

Link to Devin run: https://app.devin.ai/sessions/73b7242b9b4a47759fc1b5d8f76c3641